### PR TITLE
added ability to use [1] as the URL if the only argument is a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2018-06-14  Sebastian Hübner <sh@kokolor.es>
+  # 1.2
+
+    * requests.lua (request): Added ability to use [1] as the URL if the only argument is a table (issue: #14)
+
 2016-02-06  Louis Brauer <louis77@mac.com>
 
   # 1.1

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Run Tests:
 ## API
 
 ### Simple requests
+
 Importing the lua-requests is quite simple.
 
     > requests = require('requests')
@@ -92,7 +93,12 @@ Any request can be made with either a second argument or as a table.
 
 or
 
+    > response = requests.post{'http://httpbin.org/post', data = 'random data'}
+
+or
+
     > response = requests.post('http://httpbin.org/post', {data = 'random data'})
+
 
 NOTE: This documentation mostly uses two parameters instead of just one table because the single table feature was added later.
 

--- a/lua-requests-1.2-0.rockspec
+++ b/lua-requests-1.2-0.rockspec
@@ -1,0 +1,30 @@
+package = "lua-requests"
+version = "1.2-0"
+source = {
+  url = "git://github.com/JakobGreen/lua-requests.git"
+}
+description = {
+  summary = "HTTP requests made easy! Support for HTTPS, Basic Auth, Digest Auth. HTTP response parsing has never been easier!",
+  detailed = [[Similar to Requests for python.
+    The goal of lua-requests is to make HTTP simple and easy to use.
+    Currently HTTPS, Basic Authentication, and Digest Authentication are supported.
+    Checkout the wiki on the github page for more details. Written in pure lua!
+  ]],
+  homepage = "http://github.com/JakobGreen/lua-requests",
+  license = "MIT"
+}
+dependencies = {
+  "lua >= 5.1",
+  "lbase64",
+  "luasocket",
+  "md5",
+  "lua-cjson",
+  "xml",
+  "luasec >= 0.5.1"
+}
+build = {
+  type = "builtin",
+  modules = {
+    requests = "src/requests.lua"
+  }
+}

--- a/src/requests.lua
+++ b/src/requests.lua
@@ -67,6 +67,9 @@ function requests.request(method, url, args)
 
   if type(url) == "table" then
     request = url
+    if not request.url and request[1] then
+      request.url = table.remove(request, 1)
+    end
   else
     request = args or {}
     request.url = url


### PR DESCRIPTION
Added the ability to use table[1] as URL as requested in #14.

I tested it and it works as expected, but since I'm currently learning programming, I may have missed something.