### PR TITLE
Don't set body and Content-Length of a request when it's not needed

### DIFF
--- a/src/requests.lua
+++ b/src/requests.lua
@@ -94,11 +94,13 @@ function _requests.make_request(request)
     method = request.method,
     url = request.url,
     headers = request.headers,
-    source = ltn12.source.string(request.data),
     sink = ltn12.sink.table(response_body),
     redirect = request.allow_redirects,
     proxy = request.proxy
   }
+  if request.data then
+    full_request.source = ltn12.source.string(request.data)
+  end
 
   local response = {}
   local ok
@@ -160,7 +162,9 @@ end
 -- Add to the HTTP header
 function _requests.create_header(request)
   request.headers = request.headers or {}
-  request.headers['Content-Length'] = request.data:len()
+  if request.data then
+    request.headers['Content-Length'] = request.data:len()
+  end
 
   if request.cookies then
     if request.headers.cookie then
@@ -177,10 +181,10 @@ end
 
 --Makes sure that the data is in a format that can be sent
 function _requests.check_data(request)
-  request.data = request.data or ''
-
   if type(request.data) == "table" then
     request.data = json.encode(request.data)
+  elseif request.data then
+    request.data = tostring(request.data)
   end
 end
 


### PR DESCRIPTION
The library [copas](http://keplerproject.github.io/copas) disallow redirect when the `source` field of a request is set: https://github.com/keplerproject/copas/blob/master/src/copas/http.lua#L332
But lua-requests doesn't provide a way to not set the request body.
In addition, it is prohibited by the standard to set the request body in certain requests.
>[RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1):
>A payload within a GET request message has no defined semantics;
sending a payload body on a GET request might cause some existing
implementations to reject the request.

>[RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3):
>A message-body MUST NOT be included in a request if the specification of the request method (section 5.1.1) does not allow sending an entity-body in requests.